### PR TITLE
Make "literal" behave as specified.

### DIFF
--- a/src/ggcode.c
+++ b/src/ggcode.c
@@ -1725,7 +1725,6 @@ MODULE copy_direct_to_output (THREAD *thread)
         while (gsl_file_read (file, line))
           {
             send_text_to_output (line);
-            send_text_to_output (tcb-> gsl-> terminator);
           }
         file_close (file);
         return;


### PR DESCRIPTION
The "literal" command was adding newlines to every line, but this
is not necessary since the input newlines are preserved.

This is a rather ironic bug given the name of the command ;)

NB: due to how gsl_read_file works, this change causes input lines with
CR line endings to be output as a single, long line.
Likely not a problem unless some has ported gsl to Mac pre OSX.

BTW, I've been using gsl since 1999 or 2000 (gslgen back then).
It's a fine tool and has been a "secret" weapon on many projects.
