### PR TITLE
Remove deprication warnings for sfl build using MS Visual Studio 2010

### DIFF
--- a/src/prelude.h
+++ b/src/prelude.h
@@ -262,7 +262,7 @@
 #   include <sys\stat.h>
 #   include <sys\utime.h>
 #   include <share.h>
-#   if _MSC_VER == 1500
+#   if _MSC_VER >= 1500
 #       ifndef _CRT_SECURE_NO_DEPRECATE
 #           define _CRT_SECURE_NO_DEPRECATE   1
 #       endif


### PR DESCRIPTION
Changed prelude.h to disable deprication warning (safe string functions) for sfl when building with VS2K10.

Reason:
The version conditional is there for version 1500. MSVC 2K10 is 1600.

Change:
Use  >= instead of == for conditional.

Not in scope:
Deal with these warnings in gg\* code.
