### PR TITLE
delta must be a signed value

### DIFF
--- a/src/sflstr.c
+++ b/src/sflstr.c
@@ -1571,6 +1571,7 @@ searchreplace (
     size_t max_length)
 {
     int
+        delta,
         count = 0;
     char
         *replace,
@@ -1578,7 +1579,6 @@ searchreplace (
         *found,
         *strbase;
     size_t
-        delta,
         buf_len,
         unchanged_len,
         fnd_len,


### PR DESCRIPTION
when delta was size_t, it was always evaluated as positive
it could screw up the result if there're multiple items to replace
