### PR TITLE
fix camelCase and add PascalCase to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,7 +1132,10 @@ Neat
 :    Neat Case Modification
 
 Camel
-:    CamelCase
+:    camelCase
+
+Pascal
+:   PascalCase
 
 no
 :    No case modification


### PR DESCRIPTION
Documentation got camelCase wrong (was CamelCase).
PascalCase actually exist in code but not in documentation.
