### PR TITLE
Disable Unicode in VS builds.

### DIFF
--- a/builds/msvc/properties/Common.props
+++ b/builds/msvc/properties/Common.props
@@ -13,7 +13,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--<PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>-->
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Fixes some of the VC breaks in path handling described in https://github.com/imatix/gsl/issues/73.