### PR TITLE
Problem: residual errno side effect causes failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,8 +1653,8 @@ MODULE: GSL/fileio package
 
         Function: directory . create (path)
                     Creates directory `path`.
-        On success returns 0.
-        On error, returns -1 and sets `error`, if provided.
+        Returns 0 on success.
+        Returns -1 on error (does not accept an error parameter).
 
         Notes:
         Can create multiple levels of directories, similar to 'mkdir -p' on unix.

--- a/src/ggfile.c
+++ b/src/ggfile.c
@@ -438,8 +438,8 @@ build_directory_entries(char *pathname, char **error_msg)
 
       if (errno)
         {
-          *error_msg = xstrcpy(NULL, "'", clean_path(pathname),
-                               dirst->file_name, "' ",  strerror(errno), NULL);
+          *error_msg = xstrcpy(NULL, "'", clean_path(pathname), "' ",  
+                               strerror(errno), NULL);
         }
       else
         {

--- a/src/ggfile.c
+++ b/src/ggfile.c
@@ -427,9 +427,6 @@ build_directory_entries(char *pathname, char **error_msg)
   int
      rc;
 
-  char
-      *curpath;
-
 
   dirst = memt_alloc (NULL, sizeof (DIRST));
   rc = open_dir (dirst, pathname);

--- a/src/ggfile.gxl
+++ b/src/ggfile.gxl
@@ -207,9 +207,6 @@ build_directory_entries(char *pathname, char **error_msg)
   int
      rc;
 
-  char
-      *curpath;
-
 
   dirst = memt_alloc (NULL, sizeof (DIRST));
   rc = open_dir (dirst, pathname);

--- a/src/sfldir.c
+++ b/src/sfldir.c
@@ -93,6 +93,8 @@ open_dir (
     char
         *dir_spec,                      /*  Directory to search through      */
         *dir_spec_end;                  /*  Points to NULL in dir_spec       */
+    
+    errno = 0;
 
     ASSERT (dir != NULL);
     if (! dir)

--- a/src/sflfile.c
+++ b/src/sflfile.c
@@ -187,8 +187,8 @@ system_devicename (const char *supplied_filename)
 
     is_devicefile = TRUE;
 
-    fh = CreateFileA(supplied_filename, GENERIC_READ, FILE_SHARE_READ, NULL,
-                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    fh = CreateFileA (supplied_filename, GENERIC_READ, FILE_SHARE_READ, NULL,
+                      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
     if (fh != INVALID_HANDLE_VALUE)
       {


### PR DESCRIPTION
It's a bit challenging to follow the side effects of global `errno` state. This change only ensures that in the case of `open_dir` an uncleared error state doesn't corrupt the current call. Without this change there are at least two distinct failure scenarios in WIN32.