### PR TITLE
Problem: regexp.match broken on ARM64

### DIFF
--- a/src/ggcode.c
+++ b/src/ggcode.c
@@ -4049,14 +4049,14 @@ op2-> value. n;                    else
 
                 case OP_OR:
                     tcb-> result_node-> value. n
-                        = (double) ((Bool) tcb-> result_node-> op1-> value. n
-                        ||          (Bool) tcb-> result_node-> op2-> value. n);
+                        = (double) (tcb-> result_node-> op1-> value. n
+                        ||          tcb-> result_node-> op2-> value. n);
                     break;
 
                 case OP_AND:
                     tcb-> result_node-> value. n
-                        = (double) ((Bool) tcb-> result_node-> op1-> value. n
-                        &&          (Bool) tcb-> result_node-> op2-> value. n);
+                        = (double) (tcb-> result_node-> op1-> value. n
+                        &&          tcb-> result_node-> op2-> value. n);
                     break;
 
                 default:
@@ -4079,7 +4079,7 @@ op2-> value. n;                    else
           {
             case OP_NOT:
                 tcb-> result_node-> value. n
-                    = (double) ! (Bool) tcb-> result_node-> op2-> value. n;
+                    = (double) ! tcb-> result_node-> op2-> value. n;
                 break;
 
             case OP_PLUS:


### PR DESCRIPTION
Solution: do not cast value.n to Bool before running logical
and/or/not operations.
Casting a negative double to unsigned int is undefined behaviour, and
while on x86 it happens to do the right thing, on ARM it is broken
and "! -1" evaluates as true.
According to the C standard, logical operations are done by comparing
each operand to 0 or 0.0f in case of floating point, so the cast is
not necessary.

Fixes #131

Tested by regenerating various zproject/zproto projects (czmq, malamute, zyre) and by running this snippet on x86 and ARM platforms:

```
.if ! -1
.echo "if ! -1"
.endif
.if -1
.echo "if -1"
.endif
.if 1
.echo "if 1"
.endif
.if ! 1
.echo "if ! 1"
.endif
.if 0
.echo "if 0"
.endif
.if ! 0
.echo "if ! 0"
.endif
.if ! -10
.echo "if ! -10"
.endif
.if -10
.echo "if -10"
.endif
.if 0 & 1
.echo "if 0 & 1"
.endif
.if 0 | 1
.echo "if 0 | 1"
.endif
.if 0 & 0
.echo "if 0 & 0"
.endif
.if 0 | 0
.echo "if 0 | 0"
.endif
.if -10 & 1
.echo "if -10 & 1"
.endif
.if -10 | 1
.echo "if -10 | 1"
.endif
```