### PR TITLE
Problem: build fails on s390x

### DIFF
--- a/src/prelude.h
+++ b/src/prelude.h
@@ -90,7 +90,8 @@
  */
 
 #if (defined (__64BIT__) || defined (__x86_64__) || defined (__AARCH64EL__) \
-    || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__))
+    || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__) \
+    || defined (__s390x__))
 #    define __IS_64BIT__                /*  May have 64-bit OS/compiler      */
 #else
 #    define __IS_32BIT__                /*  Else assume 32-bit OS/compiler   */

--- a/src/sfl.h
+++ b/src/sfl.h
@@ -129,7 +129,8 @@
  */
 
 #if (defined (__64BIT__) || defined (__x86_64__) || defined (__AARCH64EL__) \
-    || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__))
+    || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__) \
+    || defined (__s390x__))
 #    define __IS_64BIT__                /*  May have 64-bit OS/compiler      */
 #else
 #    define __IS_32BIT__                /*  Else assume 32-bit OS/compiler   */


### PR DESCRIPTION
Solution: if building on s390x architecture, set \_\_IS_64BIT__