### PR TITLE
Problems: GSL does not trim whitespace, README.md out of date with gitdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,125 +1,117 @@
 
-<A name="toc1-2" title="GSL/4.1 - a Universal Code Generator" />
 # GSL/4.1 - a Universal Code Generator
 
-<A name="toc2-5" title="Contents" />
 ## Contents
 
 
-**<a href="#toc2-10">Overview</a>**
-*  <a href="#toc3-13">Contributing</a>
-*  <a href="#toc3-18">Scope and Goals</a>
-*  <a href="#toc3-25">Ownership and License</a>
-&emsp;<a href="#toc4-32">Ownership and License of generated sources</a>
-*  <a href="#toc3-37">Building and installing</a>
-&emsp;<a href="#toc4-59">Building on FreeBSD 10</a>
-&emsp;<a href="#toc4-75">Building on Cygwin</a>
-*  <a href="#toc3-107">This Document</a>
+**[Overview](#overview)**
+*  [Contributing](#contributing)
+*  [Scope and Goals](#scope-and-goals)
+*  [Ownership and License](#ownership-and-license)
+&emsp;[Ownership and License of generated sources](#ownership-and-license-of-generated-sources)
+*  [Building and installing](#building-and-installing)
+&emsp;[Building on FreeBSD 10](#building-on-freebsd-10)
+&emsp;[Building on Cygwin](#building-on-cygwin)
+*  [This Document](#this-document)
 
-**<a href="#toc2-112">Starting with GSL</a>**
-*  <a href="#toc3-141">Hello World</a>
-*  <a href="#toc3-219">Templates and Scripts</a>
-*  <a href="#toc3-296">Modeling a Web Site</a>
-*  <a href="#toc3-354">First Draft</a>
-*  <a href="#toc3-455">Inserting Variables</a>
-*  <a href="#toc3-483">Looping through Trees</a>
-*  <a href="#toc3-511">Building the Output</a>
-*  <a href="#toc3-579">Putting it All Together</a>
-*  <a href="#toc3-673">Exercise for the Reader</a>
-*  <a href="#toc3-678">Extending the Model</a>
+**[Starting with GSL](#starting-with-gsl)**
+*  [Hello World](#hello-world)
+*  [Templates and Scripts](#templates-and-scripts)
+*  [Modeling a Web Site](#modeling-a-web-site)
+*  [First Draft](#first-draft)
+*  [Inserting Variables](#inserting-variables)
+*  [Looping through Trees](#looping-through-trees)
+*  [Building the Output](#building-the-output)
+*  [Putting it All Together](#putting-it-all-together)
+*  [Exercise for the Reader](#exercise-for-the-reader)
+*  [Extending the Model](#extending-the-model)
 
-**<a href="#toc2-689">Model-Oriented Programming</a>**
-*  <a href="#toc3-700">Becoming a Very Good Programmer</a>
-*  <a href="#toc3-714">Tools that Write Software</a>
-*  <a href="#toc3-729">Abstractions and Modeling Languages</a>
-*  <a href="#toc3-748">Leverage to Move Mountains</a>
-*  <a href="#toc3-767">Case Study - OpenAMQ</a>
-*  <a href="#toc3-797">Other Model-Driven Architectures</a>
-*  <a href="#toc3-810">Why use MOP?</a>
-*  <a href="#toc3-835">A Short History of Code Generation</a>
-*  <a href="#toc3-850">Myths about Code Generation</a>
-*  <a href="#toc3-867">The Correctness of Generated Code</a>
+**[Model-Oriented Programming](#model-oriented-programming)**
+*  [Becoming a Very Good Programmer](#becoming-a-very-good-programmer)
+*  [Tools that Write Software](#tools-that-write-software)
+*  [Abstractions and Modeling Languages](#abstractions-and-modeling-languages)
+*  [Leverage to Move Mountains](#leverage-to-move-mountains)
+*  [Case Study - OpenAMQ](#case-study---openamq)
+*  [Other Model-Driven Architectures](#other-model-driven-architectures)
+*  [Why use MOP?](#why-use-mop)
+*  [A Short History of Code Generation](#a-short-history-of-code-generation)
+*  [Myths about Code Generation](#myths-about-code-generation)
+*  [The Correctness of Generated Code](#the-correctness-of-generated-code)
 
-**<a href="#toc2-884">GSL/4.1 Reference Manual</a>**
-*  <a href="#toc3-887">Command-line Syntax</a>
-*  <a href="#toc3-912">Concepts</a>
-&emsp;<a href="#toc4-915">Scalar Data Types</a>
-&emsp;<a href="#toc4-920">Structured Data Types</a>
-&emsp;<a href="#toc4-927">Constants</a>
-&emsp;<a href="#toc4-932">Scopes</a>
-&emsp;<a href="#toc4-973">Data Specifiers</a>
-&emsp;<a href="#toc4-1060">Expressions</a>
-*  <a href="#toc3-1175">Internals</a>
-&emsp;<a href="#toc4-1178">Internal Variables</a>
-&emsp;<a href="#toc4-1189">Template and Script Modes</a>
-&emsp;<a href="#toc4-1198">Template Lines</a>
-&emsp;<a href="#toc4-1205">Script Lines</a>
-&emsp;<a href="#toc4-1212">Comments</a>
-&emsp;<a href="#toc4-1230">Ignorecase</a>
-&emsp;<a href="#toc4-1235">Shuffle</a>
-&emsp;<a href="#toc4-1266">COBOL</a>
-&emsp;<a href="#toc4-1271">Line Terminators</a>
-&emsp;<a href="#toc4-1279">Escape Symbol</a>
-&emsp;<a href="#toc4-1286">Substitute Symbol</a>
-&emsp;<a href="#toc4-1295">Arguments</a>
-&emsp;<a href="#toc4-1311">Predefined Identifiers</a>
-*  <a href="#toc3-1324">Built-In Functions</a>
-&emsp;<a href="#toc4-1349">Global Functions</a>
-&emsp;<a href="#toc4-1401">conv</a>
-&emsp;<a href="#toc4-1430">diag</a>
-&emsp;<a href="#toc4-1471">environment</a>
-&emsp;<a href="#toc4-1487">fileio</a>
-&emsp;<a href="#toc4-1516">Directory Iteration</a>
-&emsp;<a href="#toc4-1781">gsl control</a>
-&emsp;<a href="#toc4-1795">math</a>
-&emsp;<a href="#toc4-1824">regexp</a>
-&emsp;<a href="#toc4-1830">process management</a>
-&emsp;<a href="#toc4-1873">script</a>
-&emsp;<a href="#toc4-1878">socket</a>
-&emsp;<a href="#toc4-1891">string</a>
-&emsp;<a href="#toc4-1923">symb</a>
-&emsp;<a href="#toc4-1928">thread</a>
-&emsp;<a href="#toc4-1965">time</a>
-&emsp;<a href="#toc4-1980">XML</a>
-*  <a href="#toc3-2028">Script Commands</a>
-&emsp;<a href="#toc4-2031">Output File Manipulation</a>
-&emsp;<a href="#toc4-2076">Control Structures</a>
-&emsp;<a href="#toc4-2188">Scope Manipulation</a>
-&emsp;<a href="#toc4-2203">Symbol Definition</a>
-&emsp;<a href="#toc4-2234">Structured Data Manipulation</a>
-&emsp;<a href="#toc4-2312">Script Manipulation</a>
-&emsp;<a href="#toc4-2342">Macros and Functions</a>
-&emsp;<a href="#toc4-2455">Miscellaneous</a>
-&emsp;<a href="#toc4-2470">Examples</a>
+**[GSL/4.1 Reference Manual](#gsl41-reference-manual)**
+*  [Command-line Syntax](#command-line-syntax)
+*  [Concepts](#concepts)
+&emsp;[Scalar Data Types](#scalar-data-types)
+&emsp;[Structured Data Types](#structured-data-types)
+&emsp;[Constants](#constants)
+&emsp;[Scopes](#scopes)
+&emsp;[Data Specifiers](#data-specifiers)
+&emsp;[Expressions](#expressions)
+*  [Internals](#internals)
+&emsp;[Internal Variables](#internal-variables)
+&emsp;[Template and Script Modes](#template-and-script-modes)
+&emsp;[Template Lines](#template-lines)
+&emsp;[Script Lines](#script-lines)
+&emsp;[Comments](#comments)
+&emsp;[Ignorecase](#ignorecase)
+&emsp;[Shuffle](#shuffle)
+&emsp;[COBOL](#cobol)
+&emsp;[Line Terminators](#line-terminators)
+&emsp;[Escape Symbol](#escape-symbol)
+&emsp;[Substitute Symbol](#substitute-symbol)
+&emsp;[Arguments](#arguments)
+&emsp;[Predefined Identifiers](#predefined-identifiers)
+*  [Built-In Functions](#built-in-functions)
+&emsp;[Global Functions](#global-functions)
+&emsp;[conv](#conv)
+&emsp;[diag](#diag)
+&emsp;[environment](#environment)
+&emsp;[fileio](#fileio)
+&emsp;[Directory Iteration](#directory-iteration)
+&emsp;[gsl control](#gsl-control)
+&emsp;[math](#math)
+&emsp;[regexp](#regexp)
+&emsp;[process management](#process-management)
+&emsp;[script](#script)
+&emsp;[socket](#socket)
+&emsp;[string](#string)
+&emsp;[symb](#symb)
+&emsp;[thread](#thread)
+&emsp;[time](#time)
+&emsp;[XML](#xml)
+*  [Script Commands](#script-commands)
+&emsp;[Output File Manipulation](#output-file-manipulation)
+&emsp;[Control Structures](#control-structures)
+&emsp;[Scope Manipulation](#scope-manipulation)
+&emsp;[Symbol Definition](#symbol-definition)
+&emsp;[Structured Data Manipulation](#structured-data-manipulation)
+&emsp;[Script Manipulation](#script-manipulation)
+&emsp;[Macros and Functions](#macros-and-functions)
+&emsp;[Miscellaneous](#miscellaneous)
+&emsp;[Examples](#examples)
 
-<A name="toc2-10" title="Overview" />
 ## Overview
 
-<A name="toc3-13" title="Contributing" />
 ### Contributing
 
 We use the C4.1 process, see: https://rfc.zeromq.org/spec:22.
 
-<A name="toc3-18" title="Scope and Goals" />
 ### Scope and Goals
 
 GSL/4.1 is a code construction tool.  It will generate code in all languages and for all purposes.  If this sounds too good to be true, welcome to 1996, when we invented these techniques.  Magic is simply technology that is twenty years ahead of its time. In addition to code construction, GSL has been used to generate database schema definitions, user interfaces, reports, system administration tools and much more.
 
 This is the fourth major version of GSL, now considered a stable product, repackaged together with its dependencies for easy building from git.
 
-<A name="toc3-25" title="Ownership and License" />
 ### Ownership and License
 
 GSL was actively developed by [iMatix Corporation](http://www.imatix.com) from 1995-2005 and is copyright &copy; 1991-2010 iMatix Corporation.  Version 4 was developed as part of the technical infrastructure for the [OpenAMQ](http://www.openamq.org) messaging product.
 
 The authors grant you free use of this software under the terms of the GNU General Public License version 3 or, at your choice, any later version. (GPLv3+). For details see the files `COPYING` in this directory.
 
-<A name="toc4-32" title="Ownership and License of generated sources" />
 #### Ownership and License of generated sources
 
 The copyright of the output of GSL is by default the property of the user or whomever writes the template(s).
 
-<A name="toc3-37" title="Building and installing" />
 ### Building and installing
 
 Dependencies:
@@ -141,7 +133,6 @@ To show command-line help:
 
     ./gsl
 
-<A name="toc4-59" title="Building on FreeBSD 10" />
 #### Building on FreeBSD 10
 
 Install GNU Make and GNU Compiler. For example, with `pkg`, `pkg install gmake gcc`. Then edit `src/Makefile` and add "-lm" to `src/Makefile` where you see CCLIBS configured. It may look similar to:
@@ -157,7 +148,6 @@ Cd to `src` and run:
     CCNAME=gcc47 gmake
     gmake install
 
-<A name="toc4-75" title="Building on Cygwin" />
 #### Building on Cygwin
 
 Install apt-cyg, a cygwin package manager:
@@ -189,12 +179,10 @@ Finally build gsl:
     make
     make install
 
-<A name="toc3-107" title="This Document" />
 ### This Document
 
 This document was written by Pieter Hintjens in October 2010 based on two 2005 articles on 'model oriented programming', and the GSL reference manual.  This text is originally at README.txt and is built using [gitdown](http://github.com/imatix/gitdown). The text was updated by Gyepi Sam in January 2013 to port documentation from earlier versions and to include more examples.
 
-<A name="toc2-112" title="Starting with GSL" />
 ## Starting with GSL
 
 GSL is an acronym for Generator Scripting Language. And that is what it does. You write scripts in gsl, feed it some data from some XML files and it generates nicely formatted text files for you. These files can be source code, a web site, a recipe book or whatever you like.
@@ -205,7 +193,6 @@ Read on to get you started with code generation!
 <img src="http://github.com/imatix/gsl/raw/master/images/README_1.png" alt="1">
 </center>
 
-<A name="toc3-141" title="Hello World" />
 ### Hello World
 
 Our first step is to make a "hello world" program in GSL. It's quite simple. Make a file called `hello.gsl` that contains one line:
@@ -283,7 +270,6 @@ If, on the other hand, we ask GSL to execute an XML file, it loads this XML file
 
 All variables that we define and use are stored in the data tree, somewhere. This is the only data structure that GSL scripts work with, and it can get very complex. For many people, understanding this complexity is the most difficult thing about using GSL - hierarchies of data are one of those things most human brains do not handle very well. We use abstractions like XNF to make this simpler, but that is something I'll discuss later.
 
-<A name="toc3-219" title="Templates and Scripts" />
 ### Templates and Scripts
 
 GSL uses the term "template" to describe text that is output as generated code. GSL works in two modes - script mode, and template mode. When you execute a GSL script directly, as we did in the first example, GSL starts in script mode. When you execute a GSL script indirectly, through an XML file, as we did in the second example, GSL starts in template mode. Try removing the `.template 0` and `.endtemplate` lines and you'll see what I mean. The script just gets copied to the output stream, the console, by default.
@@ -360,7 +346,6 @@ GSL lets you load and navigate XML data so easily that you don't even realize
 you're busy. The combination of an explicit script language like GSL plus a
 hierarchical XML data tree works well.
 
-<A name="toc3-296" title="Modeling a Web Site" />
 ### Modeling a Web Site
 
 I'm going to propose a simple abstract model for a web site, as an example. When you understand this example, you'll have a much better idea of how we design new models, so that you can design your own.
@@ -418,7 +403,6 @@ Once we've defined a set of pages, how do we tie these together into a web site?
 
 I've defined a `<section>` tag that breaks the pages into groups. Now let's jump right in and make ourselves a web site. There's no better way to test a model than to try using it. As an example, I'll make a new web site for my local grocer, who has decided, finally, to go on-line.
 
-<A name="toc3-354" title="First Draft" />
 ### First Draft
 
 We'll make the web site as several XML files. This is a design choice. We could also make the site as a single large XML file. It's a trade-off between ease of use (a single file is easier in smaller cases) and scalability (it's not practical to edit a large site with hundreds of pages as a single file).
@@ -519,7 +503,6 @@ Finally, the script saves the whole XML tree to a file. If you want to try the n
 
 GSL looks for the file called `site.xml`. When the script has run, take a look at `root.xml`. This shows you what we're going to work with to generate the real HTML.
 
-<A name="toc3-455" title="Inserting Variables" />
 ### Inserting Variables
 
 When we generate output, we insert variable values into the generated text. This is very much like using shell variables.
@@ -547,7 +530,6 @@ lets us switch off automatic case conversion, using this instruction:
 
 This tells GSL, "variable names are case sensitive, and do not convert variable values on output".
 
-<A name="toc3-483" title="Looping through Trees" />
 ### Looping through Trees
 
 In our first draft we loaded each page into the XML tree and deleted the original page definition. That was this text:
@@ -575,7 +557,6 @@ We can add more templates - to produce other types of output - for the same mode
 
 And you'll see in later examples that we tend to write a single GSL file for each output we want to produce. In XNF - the tool we use for larger-scale code generation projects - these scripts are called "targets".
 
-<A name="toc3-511" title="Building the Output" />
 ### Building the Output
 
 The HTML template looks like this:
@@ -643,7 +624,6 @@ The string() function returns a string that holds the XML value of the specified
 
 When we enclose this in `$(` and `)`, it writes the string to the current output file. Thus we generate the body of the web page.
 
-<A name="toc3-579" title="Putting it All Together" />
 ### Putting it All Together
 
 In our first draft we read the XML data from several files and we constructed a single tree with all the data we needed to generate code. This two-pass approach is the way I recommend you construct all GSL code generators:
@@ -737,12 +717,10 @@ The HTML template and the CSS file are made for each other. Note that:
 * The colors and layout of the pages is defined in the CSS stylesheet.
 * The menu is generated into each page.
 
-<A name="toc3-673" title="Exercise for the Reader" />
 ### Exercise for the Reader
 
 It's an interesting exercise to re-implement our code generator using other code generation tools. For example, if you're familiar with XSLT, try building the web site generator using that. You may find you need to cheat, for example putting the whole web site model into a single file.
 
-<A name="toc3-678" title="Extending the Model" />
 ### Extending the Model
 
 I've shown you how to design a simple model, and bring it to life using GSL. This web site generator is actually based on one that I use for some of my own web sites. You can extend this model in many directions, for instance:
@@ -753,7 +731,6 @@ I've shown you how to design a simple model, and bring it to life using GSL. Thi
 
 But most of all, the point of this example is to teach you how to use GSL in your daily work. As you've seen, it's easy to create models, and it's easy to change them. This is the secret of code generation - you don't need to get it right the first time. Models are hard to get right. So go ahead and experiment, since GSL makes it cheap to change your mind.
 
-<A name="toc2-689" title="Model-Oriented Programming" />
 ## Model-Oriented Programming
 
 This article is aimed at the professional programmer. I'm going to attack a complex subject, something that few people know about. It's a new way of programming called "model-oriented programming". I'm not going to ask you to throw out your programming languages or tools. MOP works as a layer on top of everything you know today. I am going to ask you to rethink what it means to "write a program", and to see that most of the code you write could be better written by robots, meaning other programs. And I'm going to teach you how to design and make such robots.
@@ -764,7 +741,6 @@ In this article you will learn what MOP is, and why we invented it. I'll also ex
 
 Be warned. This might hurt a little. All I can promise is that if you learn to use MOP you will use for the rest of your life, and wonder how you ever worked without it.
 
-<A name="toc3-700" title="Becoming a Very Good Programmer" />
 ### Becoming a Very Good Programmer
 
 I've learned a few things about software since I wrote my first small program in 1981 or so. First: if it's not impossible, it's not worth doing. Second: software design is about overcoming human limitations, not technical ones. Third: very few people can actually design good, useful, large-scale software systems, which for me is the goal of programming.
@@ -778,7 +754,6 @@ In my experience there are these four main aspects to becoming a very good progr
 
 Of course you also need talent, opportunity, and guidance, but a focus on portability, obsessive tool building, and years of practice can turn talent into real skill.
 
-<A name="toc3-714" title="Tools that Write Software" />
 ### Tools that Write Software
 
 In this article I'll focus on the second part, making tools. There are quite a few metaphors for software tools. For example, the Unix metaphor consists of tools as filters: read some data, do some work, produce some output. It's a simple model that lets you chain together tools. Linux has many tools that work as filters.
@@ -793,7 +768,6 @@ It's worth comparing HTML to a language like PostScript, also used to get docume
 
 I sometimes use a tool that turns HTML pages into PostScript documents. Now, as a writer, I can use HTML to write my documents and then push a button to turn this HTML into PostScript. What I am actually doing is converting a descriptive language into a programming language. A HTML-to-PostScript converter lets millions of non-technical people suddenly produce perfect programs at will. Millions of people who never think of themselves as "programmers" can write PostScript, via higher-level abstractions like HTML. And the PostScript programs they produce are much better than an average PostScript programmer can write in a reasonable time.
 
-<A name="toc3-729" title="Abstractions and Modeling Languages" />
 ### Abstractions and Modeling Languages
 
 HTML is in fact a "modeling language", a language used to describe some system or entity. Modeling languages are very interesting because they provide levels of abstraction that programming languages cannot even conceive of. Abstraction lets you define and use high-level concepts like, "this is a document title", without having to specify what that actually means, on paper or on the screen. Abstraction relies on concepts that have enough meaning to be useful, without being too detailed. For example, "the web" is a useful abstraction for "various URL formats, protocols for transferring such resources, clients and servers that implement such protocols, and collections of resources that are thus interconnected".
@@ -812,7 +786,6 @@ For naive users, a model is a visual thing, but for us programmers, a textual mo
 
 Libero took me about three months to build, time that I've won back on many projects. In a general sense, Libero is like the HTML-to-PostScript convertor. It takes a definition written in an abstract modeling language and turns that into code that makes the model come to life. The generated code is always perfect, and as invisible as the PostScript code.
 
-<A name="toc3-748" title="Leverage to Move Mountains" />
 ### Leverage to Move Mountains
 
 I'm coming to the point of this article. This kind of model-to-code tool is very useful. It gives you leverage. That is, the ability to move mountains. It is much easier, faster, cheaper to change an abstract model than it is to change the code that makes it work. Look again at a PostScript program and now imagine the work needed to change a H1 item to H2.
@@ -831,7 +804,6 @@ I've said that part of being a world-class programmer is the ability to make use
 
 If you've ever studied how compilers work, it's much the same problem. What I'm talking about is building compilers for modeling languages.
 
-<A name="toc3-767" title="Case Study - OpenAMQ" />
 ### Case Study - OpenAMQ
 
 Modeling languages and programming languages can overlap. For example, objects are a type of model. The biggest problem with putting models into the programming language is that for real, large problems, we need many different types of model, and these cannot be expressed in a single language. Languages that attempt this become too complex to work with. Imagine attempting to describe a hierarchical document using objects, and compare this to writing some HTML by hand.
@@ -861,7 +833,6 @@ Let me take you through the main parts of our architecture:
 
 These tools - which are included in the OpenAMQ distribution's `base2` project - are somewhat unusual. The techniques of code generation are not well understood, and no teams have ever pushed these techniques as far as we have. I don't promise that it will be easy to understand - abstraction can be hard to grasp - but once you "get it", you'll be able to produce tools that solve your programming problems ten times faster than using any other technique.
 
-<A name="toc3-797" title="Other Model-Driven Architectures" />
 ### Other Model-Driven Architectures
 
 Using models as the basis for designing applications is not new. I've worked with many tools that promised "an end to programming" through the magic of point and click modeling. Some of these - such as UML (Universal Modeling Language) - have become industry standards. In my experience, these tools do not work except as expensive and slow documentation tools.
@@ -874,7 +845,6 @@ Classic MDA tools attempt to do everything with a single modeling language. This
 
 To succeed with a model-driven architecture, you need a way to build, test, and improve a variety of different models, each solving one specific domain. What you need is not a single, do-it-all modeling language, but a technology that lets you build arbitrary modeling languages.
 
-<A name="toc3-810" title="Why use MOP?" />
 ### Why use MOP?
 
 Despite the trendy name, MOP is really about solving real problems in the most efficient possible way. Let's look at the main advantages my team gets from using MOP:
@@ -899,7 +869,6 @@ So, MOP is best used in small, skilled, and long-lasting teams (like iMatix) tha
 
 The sad thing in the software business is that few people actually understand that better techniques save money. Still, there is no pleasure, as a programmer, in writing bad code using bad tools. So, learn to use MOP, then convince your bosses that they will save money, right away, by using this. Everyone wins.
 
-<A name="toc3-835" title="A Short History of Code Generation" />
 ### A Short History of Code Generation
 
 To understand and use MOP you need to appreciate code generation as a technology. I first started writing code generators in 1985, and I've seen these tools evolve through several stages (in my own work, but also in the general domain):
@@ -914,7 +883,6 @@ To understand and use MOP you need to appreciate code generation as a technology
 
 Our first versions of GSL were born in 1995. We moved onto XML in 1997. The problem of writing the code generator scripting language (GSL) is largely solved, and at iMatix we don't consider this a priority task. At some point we want to rewrite GSL to be a lot faster, but what interests us now is using MOP techniques to solve difficult problems.
 
-<A name="toc3-850" title="Myths about Code Generation" />
 ### Myths about Code Generation
 
 Code generators are often seen as a technological burden, rather than useful tools. I suspect that this is because primitive code generators (which covers most code generators) are so painful to use. Some of the common myths about code generation are:
@@ -931,7 +899,6 @@ Code generators are often seen as a technological burden, rather than useful too
 
 GSL solves most of these problems, and even a beginner can make useful code generators for interfaces, database management, XNF solves the last problem - it applies MOP to MOP itself, letting us make sophisticated code generators much more rapidly than by hand.
 
-<A name="toc3-867" title="The Correctness of Generated Code" />
 ### The Correctness of Generated Code
 
 When you use a tool that produces large amounts of code for you, you will naturally ask, "how do I know the code is correct". You need to be able to trust your tools.
@@ -948,10 +915,8 @@ In any programming environment, the key to producing good code is to test heavil
 
 Since we use the MOP approach to build the code generators themselves, we get very good code generators, cheaply. It is the same concept as a "self-hosting" compiler. On many projects where we've used MOP, I'm able to deliver hundreds of thousands of lines of code, and say, with confidence, "there is not a single bug in this code".
 
-<A name="toc2-884" title="GSL/4.1 Reference Manual" />
 ## GSL/4.1 Reference Manual
 
-<A name="toc3-887" title="Command-line Syntax" />
 ### Command-line Syntax
 
 To run GSL, use one of the following syntaxes:
@@ -976,27 +941,22 @@ Command-line attributes are loaded with an XML file and are available to a scrip
 
 If GSL found an XML file, it loads it, then looks for an attribute named script of the top-level item.  This name is used to find a GSL script to interpret.  If GSL found a GSL file, it begins interpreting it without loading an XML file.
 
-<A name="toc3-912" title="Concepts" />
 ### Concepts
 
-<A name="toc4-915" title="Scalar Data Types" />
 #### Scalar Data Types
 
 GSL recognises two scalar data types: numeric and string.  It generally makes no formal distinction between them; if a value looks numeric, then it is treated as such, otherwise it is treated as a string.  If strict typing is required, the type conversion functions `conv.number` and `conv.string` can be used.
 
-<A name="toc4-920" title="Structured Data Types" />
 #### Structured Data Types
 
 GSL also understands structured data types.  Structured data types are modelled on XML; they have a name, attributes and children.  Attributes and children may be of a scalar type or (unlike XML) a structured type. An attribute effectively represents a 1:1 link while children represent 1:n links.
 
 Structured data types are used to represent underlying data, and the attributes and children are based on their structure.  The archetypal case is XML data; its particularities mean that children are also XML items, attributes may only have scalar values while both children and attributes may have any name.
 
-<A name="toc4-927" title="Constants" />
 #### Constants
 
 Constants express a constant value of one of the two scalar types. A string constant is specified with either single- or double-quotes as delimiters, for example: `"ABC"`.   String constants may continue over several source lines.  The line break is considered part of the string constant, unless the last character in the line is a single backslash (`\`) in which case neither the backslash nor the line break is part of the string.  A numeric constant is a simple number with an optional sign and optional decimal characters, for example 123 and -0.3.
 
-<A name="toc4-932" title="Scopes" />
 #### Scopes
 
 According to The Free On-line Dictionary of Computing, &copy; 1993-2004 Denis Howe:
@@ -1037,7 +997,6 @@ Before processing a script, GSL defines several scopes.  These need to be taken 
 
 * The fifth and final predefined scope is the top-level XML item from the XML source file, if one was specified.
 
-<A name="toc4-973" title="Data Specifiers" />
 #### Data Specifiers
 
 A data specifier is the means by which you access an item of data.  GSL provides a variety of ways to access a particular piece of data.
@@ -1124,7 +1083,6 @@ GSL has two modes of handling the case of identifiers.  In the default mode, GSL
 
 To change modes, set the value of the identifier `ignorecase` in the gsl scope to 0 or 1.  Eg: `[gsl].ignorecase = 0'
 
-<A name="toc4-1060" title="Expressions" />
 #### Expressions
 
 GSL expressions are much the same as expressions in other high-level programming languages.  They include the following operators:
@@ -1239,10 +1197,8 @@ Some examples:  Assume the identifier `IDENT` has the value `NUM` and identifer 
 
 <tt>&#36;(&#36;(ident))</tt>+1: `2`
 
-<A name="toc3-1175" title="Internals" />
 ### Internals
 
-<A name="toc4-1178" title="Internal Variables" />
 #### Internal Variables
 
 GSL has a series of internal variables, described below, that influence its behaviour in various ways.  These variables are held in the scope `gsl` and can be modified by an instruction of the form:
@@ -1253,7 +1209,6 @@ You can also set the initial value of these variables when starting GSL by using
 
     gsl -xxxxx:yyyy somescript.gsl
 
-<A name="toc4-1189" title="Template and Script Modes" />
 #### Template and Script Modes
 
 Lines of GSL may be either script lines or template lines.  GSL has two different modes for distinguishing script from template lines.  In template mode, lines are assumed to be template lines unless they begin with a period (`.`).  In script mode, lines are assumed to be script lines unless they begin with a greater-than symbol (`>`).
@@ -1262,21 +1217,18 @@ GSL starts in one of these modes, depending on the manner in which is was invoke
 
 You can change between template and script mode with the `template` and `endtemplate` commands.  See the description of these commands below for details.
 
-<A name="toc4-1198" title="Template Lines" />
 #### Template Lines
 
 The simplest template line is just text, which is copied verbatim to the current output file.  If no output file has been opened, or if the last output file has been closed, the output is copied to the standard output.
 
 The backslash (`\`) serves several special functions in a template line.  Firstly, if the last character of an template line is a backslash, then the line is output with no line terminator; otherwise a line terminator follows the template line.  Secondly, a backslash introduces one of three special character sequences: `\n`, `\r` and `\t` which are replaced by a line feed, carriage return and a tabulation character (TAB) respectively.  Thirdly, a backslash followed by and other character is replaced by that character; this allows characters which would normally be interpreted as script commands to be output literally.
 
-<A name="toc4-1205" title="Script Lines" />
 #### Script Lines
 
 The script commands are described below.
 
 If a script command line ends with a backslash (`\`), then the following script line is treated as a continuation of the current line.
 
-<A name="toc4-1212" title="Comments" />
 #### Comments
 
 There are three ways to include comments in GSL scripts.  The first is to place a hyphen (`-`) as the first character of a script line, or following the point (`.`) in a template line.  The second way is to place a hash (`#`) after a GSL command.  Any characters following the hyphen are ignored by GSL.  The third way is to enclose comment text (which may continue over more than one line) inside comment markers (`/*` and `*/`) just as in C.  However if GSL finds these characters in a template line (but not inside a substitution) it assumes that they are destined for output, so does not treat them as a comment.
@@ -1294,12 +1246,10 @@ Examples:
 
     $("but "/* this is */)
 
-<A name="toc4-1230" title="Ignorecase" />
 #### Ignorecase
 
 GSL has two modes which influence case-sensitivity of identifier names. In the first mode (ignore-case), GSL is case-insensitive regarding identifier names and instead as a guide to modifying the output string, as described above (`Case Sensitivity`).  In the second mode (case-sensitive), GSL treats the case of identifier names as significant.  You can change the behaviour by setting the value of the attribute `ignorecase` in the scope `gsl` to 1 for ignore case and 0 for case sensitivity.
 
-<A name="toc4-1235" title="Shuffle" />
 #### Shuffle
 
 GSL can help to keep code neat by enlarging or shrinking white space so that column numbers match as far as possible between the script and the output file.  For instance, if the value of the identifier X is ABCDEF, then:
@@ -1330,12 +1280,10 @@ evaluates to
 
 Shuffle can cause problems in some cases, for example when outputting literal text where the size of white space is important.  In this case shuffle should be disabled by setting the value to zero.
 
-<A name="toc4-1266" title="COBOL" />
 #### COBOL
 
 GSL helps you make neat COBOL code by automatically filling the first six characters of each line with the four-digit line number followed by two zeroes.  To enable this function set the value of the attribute `cobol` in the gsl scope to 1.
 
-<A name="toc4-1271" title="Line Terminators" />
 #### Line Terminators
 
 GSL uses as its line terminator the value of of the attribute `terminator` of the gsl scope.  The default value is "\n" but it could also be set to "\r\n", for example.
@@ -1343,14 +1291,12 @@ GSL uses as its line terminator the value of of the attribute `terminator` of th
     \# for Windows batch scripts
     \.terminator="\n\r"
 
-<A name="toc4-1279" title="Escape Symbol" />
 #### Escape Symbol
 
 GSL uses the backslash "\" as its default escape symbol, mainly due to its POSIX / C roots. This can be very annoying in templates that have a lot of backslashes. You can override the escape symbol by changing the [gsl].escape attribute, or using the -escape:X command-line switch.
 
 Note that this takes effect for the next script loaded, so you cannot use this in a script to modify how that script itself is processed. You can use it before e.g. including a script.
 
-<A name="toc4-1286" title="Substitute Symbol" />
 #### Substitute Symbol
 
 GSL uses the string `$(` to open a substitution sequence. You can use any string instead, by changing the [gsl].substitute attribute, or using the -substitute:X command-line switch.
@@ -1359,7 +1305,6 @@ Note that this takes effect for the next script loaded, so you cannot use this i
 
 Note also that the closing symbol is always `)` and you cannot override this.
 
-<A name="toc4-1295" title="Arguments" />
 #### Arguments
 
 If GSL is invoked with a `-a` switch, all arguments following the first are treated as arguments to the first script, rather than as further arguments to GSL, as would otherwise be the case.  So if you type:
@@ -1375,7 +1320,6 @@ or in a loop:
     n = 1
     echo switches.arg$(n)
 
-<A name="toc4-1311" title="Predefined Identifiers" />
 #### Predefined Identifiers
 
 There are some identifiers whose value is maintained by GSL in the global space referred to by the predefined scopes `gsl` and `global`.  They are defined as attributes of the global item.
@@ -1388,7 +1332,6 @@ There are some identifiers whose value is maintained by GSL in the global space 
 * `version`: The version of the current application.
 * `switches`: A symbol table holding all the command-line switches present when GSL was invoked.
 
-<A name="toc3-1324" title="Built-In Functions" />
 ### Built-In Functions
 
 GSL provides many built-in functions and uses `modules` to group related functions.
@@ -1413,7 +1356,6 @@ Some functions accept an optional parameter, listed as `error`. If the parameter
     endif
 ```
 
-<A name="toc4-1349" title="Global Functions" />
 #### Global Functions
 
     alias (item)
@@ -1465,7 +1407,6 @@ Some functions accept an optional parameter, listed as `error`. If the parameter
     which ()
         To be explained.
 
-<A name="toc4-1401" title="conv" />
 #### conv
 
 MODULE: GSL/conv package
@@ -1494,7 +1435,6 @@ MODULE: GSL/conv package
 
 
 
-<A name="toc4-1430" title="diag" />
 #### diag
 
 MODULE: GSL/diag package
@@ -1535,7 +1475,6 @@ MODULE: GSL/diag package
 
 
 
-<A name="toc4-1471" title="environment" />
 #### environment
 
 MODULE: GSL/environment package
@@ -1551,7 +1490,6 @@ MODULE: GSL/environment package
 
 
 
-<A name="toc4-1487" title="fileio" />
 #### fileio
 
 GSL provides three modules for dealing with directories and files; one directory module and two file modules, one for working with independent files and the second for working with files during a directory traversal. We will discuss the second set after the first because it will make more sense that way.
@@ -1580,7 +1518,6 @@ The offset changes to reflect any read or write operations on the file. This is 
 
 The final set of file functions manipulate files, file names and file metadata.
 
-<A name="toc4-1516" title="Directory Iteration" />
 #### Directory Iteration
 
 As mentioned, previously, directories can be opened with the `directory.open` function, which returns a 'directory entry' object.
@@ -1845,7 +1782,6 @@ MODULE: GSL/fileio package
 
 
 
-<A name="toc4-1781" title="gsl control" />
 #### gsl control
 
     Class: GSL Control Class
@@ -1859,7 +1795,6 @@ MODULE: GSL/fileio package
             its output is returned as the result of this function. Uses the
             current template mode unless over-ridden by the optional argument.
 
-<A name="toc4-1795" title="math" />
 #### math
 
     Class: Math Functions
@@ -1888,13 +1823,11 @@ MODULE: GSL/fileio package
         Function: math . acosh (parm)
         Function: math . atanh (parm)
 
-<A name="toc4-1824" title="regexp" />
 #### regexp
 
     Class: Regular Expression Functions
         Function: regexp . match (pattern,subject,[match])
 
-<A name="toc4-1830" title="process management" />
 #### process management
 
 MODULE: GSL/process management
@@ -1937,12 +1870,10 @@ package
 
 
 
-<A name="toc4-1873" title="script" />
 #### script
 
     Class: GSL Script Line
 
-<A name="toc4-1878" title="socket" />
 #### socket
 
     Class: Socket
@@ -1955,7 +1886,6 @@ package
         Function: <sock handle> . read (buffer,[minimum],[timeout],[error])
         Function: <sock handle> . write (buffer,[timeout],[error])
 
-<A name="toc4-1891" title="string" />
 #### string
 
     Class: String Functions
@@ -1987,12 +1917,10 @@ package
         Function: string . soundex (string)
         Function: string . cntch (string,value)
 
-<A name="toc4-1923" title="symb" />
 #### symb
 
     Class: Symbol
 
-<A name="toc4-1928" title="thread" />
 #### thread
 
     Class: Thread
@@ -2029,7 +1957,6 @@ package
     Class: Thread
         Function: <parsed item> . run ([error])
 
-<A name="toc4-1965" title="time" />
 #### time
 
     Class: Time Functions
@@ -2044,7 +1971,6 @@ package
         Function: date . picture ([date],[picture])
         Function: date . number (date)
 
-<A name="toc4-1980" title="XML" />
 #### XML
 
     Class: XML
@@ -2092,10 +2018,8 @@ package
 
     Class: XML value
 
-<A name="toc3-2028" title="Script Commands" />
 ### Script Commands
 
-<A name="toc4-2031" title="Output File Manipulation" />
 #### Output File Manipulation
 
 **.output**
@@ -2140,7 +2064,6 @@ Examples:
     things like $(abc).
     .endliteral
 
-<A name="toc4-2076" title="Control Structures" />
 #### Control Structures
 
 **.for**
@@ -2252,7 +2175,6 @@ Inside a `for` or `while` loop, causes immediate iteration, skipping execution o
 
 Inside a `for` or `while` loop, causes the loop to terminate iteration immediately.  Control passes to the line following the `endfor` or `endwhile` statement.  If the scope is specified, then the `for` loop corresponding to that scope is terminated.
 
-<A name="toc4-2188" title="Scope Manipulation" />
 #### Scope Manipulation
 
 **.scope**
@@ -2267,7 +2189,6 @@ Opens a new scope corresponding to the specified data.
 
 Terminates a block opened with a `.scope` command, closing the scope. The scope name is optional and does not affect the operation.  GSL confirms that its value is the name of the scope to be closed and reports an error if this is not the case.  In this way, GSL can be made to validate nested `.scope` blocks for you.
 
-<A name="toc4-2203" title="Symbol Definition" />
 #### Symbol Definition
 
     .<data-specifier> [<operator>]= [ <expr> ]
@@ -2298,7 +2219,6 @@ Multiplies the value of the identifier x by 2.
 
 Does nothing if `x` is already defined; otherwise assigns it the value of `y`, or if `y` is undefined, then the value of `z`, or if `z` is undefined, `x` remains undefined.
 
-<A name="toc4-2234" title="Structured Data Manipulation" />
 #### Structured Data Manipulation
 
 **.new**
@@ -2376,7 +2296,6 @@ Examples:
 
 Sorts the specified items.  A scope is created with each item in turn and is used to evaluate the expression.  The result is then used to sort the items.  The `as` clause allows you to give the created scope a different name.  After execution, the specified items are in order and after any other children of the same parent.
 
-<A name="toc4-2312" title="Script Manipulation" />
 #### Script Manipulation
 
 **.include**
@@ -2406,7 +2325,6 @@ Turns template mode on or off.
 
 Terminates the block introduced by a `template` instruction.
 
-<A name="toc4-2342" title="Macros and Functions" />
 #### Macros and Functions
 
 Macros and functions are pieces of GSL which can be invoked with parameters. The only difference between a macro and a function is that macros are interpreted in template mode and functions in script mode.
@@ -2519,7 +2437,6 @@ produces
     1
     2
 
-<A name="toc4-2455" title="Miscellaneous" />
 #### Miscellaneous
 
 **.echo**
@@ -2534,7 +2451,6 @@ Outputs the given expression to the standard output.
 
 Outputs the given expression to the standard output and halts GSL operation.
 
-<A name="toc4-2470" title="Examples" />
 #### Examples
 
 See examples in Examples directory

--- a/src/ggcomm.c
+++ b/src/ggcomm.c
@@ -1212,6 +1212,8 @@ concatenate_results (RESULT_NODE *r,
     char
       **blk,
        *txt,
+       *line_end,
+       *last_line,
        *rc;
 
     if (error_text)
@@ -1343,6 +1345,26 @@ concatenate_results (RESULT_NODE *r,
       }
 
     rc [totlines * totlinelength] = 0;
+
+    /*  Trim whitespace from all lines  */
+    txt = rc;
+    while (txt)
+      {
+         line_end = strchr(txt, '\n');
+         if (!line_end)
+           break;
+         if (*(line_end - 1) == '\r')
+           line_end = line_end - 1;
+         last_line = line_end;
+         while (last_line > txt)
+           {
+             if (!isspace (*(last_line - 1)))
+                 break;
+             last_line--;
+           }
+         memmove(last_line, line_end, strlen(line_end) + 1);
+         txt = last_line + (*last_line == '\r' ? 2 : 1);
+      }
 
     /*  JS Blunder check  */
     ASSERT (runlength == totlinelength);


### PR DESCRIPTION
Solutions: add another pass over the text to trim all excessive whitespace if there are no other character types till the line feed. Due to the way the "block" formatting is built, by first allocating a buffer full of spaces and then writing the actual text over it, this is the simplest and less intrusive way to fix the problem.
A different solution would require reimplementing the block formatter from scratch.
Tested on CZMQ, and it produces a massive but working diff.
Fixes https://github.com/imatix/gsl/issues/54

Also regenerate the README.md, as the headers were broken.